### PR TITLE
Spruce up webpack config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
           publish_branch: gh-pages
+          cname: www.yuankunandryan.com
           user_name: lopopolo
           user_email: rjl@hyperbo.la
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3325,12 +3325,6 @@
         "mimic-response": "^1.0.0"
       }
     },
-    "cname-webpack-plugin": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cname-webpack-plugin/-/cname-webpack-plugin-3.0.0.tgz",
-      "integrity": "sha512-kL+C2Xwiev19vE5vOpVsUGelnGiebJtap6u9s29IsQ2cEoLcLmSeAiWI0aVsUTRzgOjnLuEmTu+MbqMDKVIjyw==",
-      "dev": true
-    },
     "coa": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@babel/core": "^7.12.9",
     "@babel/preset-env": "^7.12.7",
     "babel-loader": "^8.2.2",
-    "cname-webpack-plugin": "^3.0.0",
     "css-loader": "^5.0.1",
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^4.5.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,4 @@
 const path = require("path");
-const CnameWebpackPlugin = require("cname-webpack-plugin");
 const HtmlWebPackPlugin = require("html-webpack-plugin");
 const TerserPlugin = require("terser-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
@@ -13,34 +12,24 @@ const plugins = [
   new HtmlWebPackPlugin({
     template: "index.html",
     filename: "index.html",
-    minify: {
-      collapseWhitespace: true,
-      minifyCSS: true,
-      minifyJS: true,
-      removeComments: true,
-      useShortDoctype: true,
-    },
   }),
   new HtmlWebPackPlugin({
     template: "save-the-date.html",
     filename: "save-the-date/index.html",
-    minify: {
-      collapseWhitespace: true,
-      minifyCSS: true,
-      minifyJS: true,
-      removeComments: true,
-      useShortDoctype: true,
-    },
-  }),
-  new CnameWebpackPlugin({
-    domain: "www.yuankunandryan.com",
   }),
 ];
 
-module.exports = (env, argv) => {
+module.exports = (_env, argv) => {
   let cssLoader = "style-loader";
+  let optimization = {
+    minimize: false,
+  };
   if (argv.mode === "production") {
     cssLoader = MiniCssExtractPlugin.loader;
+    optimization = {
+      minimize: true,
+      minimizer: [new TerserPlugin(), new OptimizeCSSAssetsPlugin()],
+    };
   }
   return {
     context: path.resolve(__dirname, "src"),
@@ -82,9 +71,6 @@ module.exports = (env, argv) => {
       ],
     },
     plugins,
-    optimization: {
-      minimize: true,
-      minimizer: [new TerserPlugin(), new OptimizeCSSAssetsPlugin()],
-    },
+    optimization,
   };
 };


### PR DESCRIPTION
- Remove `cname-webpack-plugin`.
- Set GitHub Pages CNAME with publish GitHub Action.
- Remove always-configured `HtmlWebpackPlugin` minify block.
  `HtmlWebpackPlugin` automatically enables a good set of minify
  settings when in `mode = production`.
- Dynamically set minification settings in `webpack.config.js` based on
  whether `mode == production`.